### PR TITLE
Invitepage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,31 @@
 import { useState } from "react";
 import { StartPage } from "./Pages/StartPage";
+import { InvitePage } from "./Pages/InvitePage";
 import { GamePage } from "./Pages/GamePage";
 
 function App() {
-  const [showGamePage, setShowGamePage] = useState(false);
+  const [page, setPage] = useState<"start" | "invite" | "game">("start");
+  const [gameId, setGameId] = useState("");
 
-  return showGamePage ? (
-    <GamePage onBack={() => setShowGamePage(false)} />
-  ) : (
-    <StartPage onStartGame={() => setShowGamePage(true)} />
-  );
+  function handleStartGame() {
+    const newGameId = Math.random().toString(36).substring(2, 8).toUpperCase();
+    setGameId(newGameId);
+    setPage("invite");
+  }
+
+  function handleContinue() {
+    setPage("game");
+  }
+
+  if (page === "invite") {
+    return <InvitePage gameId={gameId} onContinue={handleContinue} />;
+  }
+
+  if (page === "game") {
+    return <GamePage onBack={() => setPage("start")} />;
+  }
+
+  return <StartPage onStartGame={handleStartGame} />;
 }
 
 export default App;

--- a/frontend/src/Pages/InvitePage.tsx
+++ b/frontend/src/Pages/InvitePage.tsx
@@ -1,0 +1,50 @@
+import "../css/InvitePage.css";
+import copyIcon from "../assets/copy.svg";
+
+type InvitePageProps = {
+  gameId: string;
+  onContinue: () => void;
+};
+
+export function InvitePage({ gameId, onContinue }: InvitePageProps) {
+  const inviteLink = `${window.location.origin}/join/${gameId}`;
+
+  return (
+    <div className="invite-container">
+      <h1 className="title">Invite player 2 to join your game</h1>
+      <p className="tag-line">Share this link with your friend</p>
+
+      <div className="form-section">
+
+        <div className="info-box">
+          <p className="info-label">Game ID:</p>
+
+          <div className="info-row">
+            <span className="info-value">{gameId}</span>
+            <button className="copy-btn">
+              <img src={copyIcon} alt="Copy" />
+            </button>
+          </div>
+        </div>
+
+        <div className="info-box">
+          <p className="info-label">Invite Link:</p>
+
+          <div className="info-row">
+            <span className="info-value">{inviteLink}</span>
+            <button className="copy-btn">
+              <img src={copyIcon} alt="Copy" />
+            </button>
+          </div>
+        </div>
+
+        <div className="button-group">
+          <button className="btn Start" onClick={onContinue}>
+            Continute to Game
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Pages/StartPage.tsx
+++ b/frontend/src/Pages/StartPage.tsx
@@ -18,7 +18,7 @@ export function StartPage({ onStartGame }: StartPageProps) {
         </div>
 
         <div className="button-group">
-          <button className="btn Start" type="button" onClick={onStartGame}>Start Game</button>
+          <button className="btn Start" type="button" onClick={onStartGame}>Invite player</button>
         </div>
       </div>
     </div>

--- a/frontend/src/css/InvitePage.css
+++ b/frontend/src/css/InvitePage.css
@@ -36,37 +36,50 @@
 
 .info-box {
   width: 100%;
+  background: rgba(20, 20, 20, 0.85);
+  padding: 18px 20px;
+  border-radius: 12px;
+  box-shadow:
+    0 0 10px rgba(255, 0, 0, 0.25),
+    0 0 25px rgba(255, 0, 0, 0.15);
+  border: 1px solid rgba(255, 0, 0, 0.3);
 }
 
 .info-label {
-  color: rgb(200, 200, 200);
-  margin-bottom: 6px;
+  color: rgb(255, 120, 120);
+  font-size: 14px;
+  margin-bottom: 8px;
+  letter-spacing: 1px;
 }
 
 .info-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: space-between;
 }
 
 .info-value {
   color: white;
-  font-size: 16px;
+  font-size: 17px;
+  font-weight: 500;
   word-break: break-all;
+  max-width: 85%;
 }
 
 .copy-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 4px;
+  transition: transform 0.15s ease;
 }
 
 .copy-btn img {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
+  filter: drop-shadow(0 0 4px rgba(255, 0, 0, 0.6));
 }
 
 .button-group {
-  margin-top: 20px;
+  transform: scale(1.15);
 }

--- a/frontend/src/css/InvitePage.css
+++ b/frontend/src/css/InvitePage.css
@@ -1,0 +1,72 @@
+.invite-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 80px;
+  color: rgb(143, 6, 6);
+  font-family: 'Inter', sans-serif;
+}
+
+.title {
+  font-size: 48px;
+  font-weight: 700;
+  color: rgb(136, 22, 22);
+  letter-spacing: 1px;
+  text-shadow:
+    0 0 10px rgba(153, 12, 12, 0.6),
+    0 0 20px rgba(235, 18, 18, 0.4),
+    0 0 40px rgba(70, 4, 4, 0.2);
+}
+
+.tag-line {
+  color: rgb(136, 22, 22);
+  font-size: 18px;
+  letter-spacing: 1px;
+  margin-top: 10px;
+}
+
+.form-section {
+  margin-top: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 320px;
+  gap: 30px;
+}
+
+.info-box {
+  width: 100%;
+}
+
+.info-label {
+  color: rgb(200, 200, 200);
+  margin-bottom: 6px;
+}
+
+.info-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.info-value {
+  color: white;
+  font-size: 16px;
+  word-break: break-all;
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.copy-btn img {
+  width: 18px;
+  height: 18px;
+}
+
+.button-group {
+  margin-top: 20px;
+}


### PR DESCRIPTION
created the new InvitePage, which is shown to Player 1 after starting a game.
InvitePage displays the generated Game ID and a shareable invite link, both styled in a clean card layout with copy buttons. This allows Player 1 to easily copy and send the link to Player 2.

JoinPage is not accessible yet, because we have not added a route/path for /join/:gameId.
Once routing is implemented, Player 2 will be able to open the invite link and automatically land on JoinPage.