### PR TITLE
Add IsGameReady logic, tests, and fix test environment config

### DIFF
--- a/backend.Tests/IsGameReady.cs
+++ b/backend.Tests/IsGameReady.cs
@@ -1,0 +1,28 @@
+using Xunit;
+using wndgame;
+
+namespace backend.Tests;
+
+public class IsGameReadyTest
+{
+  [Fact]
+  public async Task IsGameReady_ShouldReturnFalse_WhenOnlyOnePlayerExists()
+  {
+    var service = new GameService();
+    var game = await service.CreateGame("TESTORD", "Spelare A");
+
+    var result = await service.IsGameReady(game.Id);
+    Assert.False(result);
+  }
+
+  [Fact]
+  public async Task IsGameReady_ShouldReturnTrue_WhenTwoPlayersExist()
+  {
+    var service = new GameService();
+    var game = await service.CreateGame("TESTORD", "Spelare A");
+    await service.JoinGame(game.Id, "Spelare B");
+
+    var result = await service.IsGameReady(game.Id);
+    Assert.True(result);
+  }
+}

--- a/backend/GameService.cs
+++ b/backend/GameService.cs
@@ -111,5 +111,11 @@ public class GameService
         }
         */
     }
+    // Väntar på att båda spelarna ska vara redo
+    public async Task<bool> IsGameReady(string gameId)
+    {
+        var players = await GetPlayersInGame(gameId);
+        return players.Count == 2;
+    }
 }
 


### PR DESCRIPTION
Implemented the IsGameReady method in GameService to determine when a game is ready to start based on the number of players.
Added a new test file IsGameReadyTest.cs with test cases for both one-player and two-player scenarios.

Also resolved a test environment issue where SupabaseConfig failed to load due to missing configuration.
Added the required db-config.env setup so backend.Tests can initialize GameService correctly.